### PR TITLE
Reimplment how _layoutQuickActionButtons calculates the frames

### DIFF
--- a/Tweak.h
+++ b/Tweak.h
@@ -1,8 +1,27 @@
-@interface UIView (SpringBoardAdditions)
-- (void)sb_removeAllSubviews;
+@interface SBDashBoardQuickActionsButton : UIView
+-(void)setEdgeInsets:(UIEdgeInsets)arg1;
 @end
 
 @interface SBDashBoardQuickActionsView : UIView
+@property (nonatomic, retain) SBDashBoardQuickActionsButton *flashlightButton;
+@property (nonatomic, retain) SBDashBoardQuickActionsButton *cameraButton;
+- (UIEdgeInsets)_buttonOutsets;
 - (void)_layoutQuickActionButtons;
-- (void)handleButtonPress:(id)arg1 ;
+- (void)handleButtonPress:(id)arg1;
+@end
+
+@interface SBDashBoardQuickActionsViewController : UIViewController
+-(SBDashBoardQuickActionsView *)quickActionsViewIfLoaded;
+@end
+
+@interface UIScreen (ShortcutEnablerPrivate)
+@property (nonatomic, readonly) CGRect _referenceBounds;
+@end
+
+@interface SBDashBoardViewController : UIViewController
+@end
+
+@interface SBLockScreenManager : NSObject
+@property (nonatomic, readonly) SBDashBoardViewController *dashBoardViewController;
++(SBLockScreenManager *)sharedInstanceIfExists;
 @end

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -1,9 +1,7 @@
 #import "Tweak.h"
 
 static BOOL showFlashlight, showCamera, require3DTouch;
-static double flashlightX, flashlightY, cameraX, cameraY;
-
-static BOOL settingsUpdated = NO;
+static CGFloat flashlightX, flashlightY, cameraX, cameraY;
 
 %hook SBDashBoardQuickActionsViewController
 + (BOOL)deviceSupportsButtons {
@@ -19,45 +17,39 @@ static BOOL settingsUpdated = NO;
 }
 %end
 
+static inline CGFloat GetButtonSize(CGRect screenBounds) {
+	if (screenBounds.size.height >= 812)
+		return 58;
+	if (screenBounds.size.height >= 736)
+		return 50;
+	return 42;
+}
+
 %hook SBDashBoardQuickActionsView
 - (void)_layoutQuickActionButtons {
-	%orig;
-	for (UIView *subview in self.subviews) {
+	UIEdgeInsets insets = [self _buttonOutsets];
+	[self.flashlightButton setEdgeInsets:insets];
+	[self.cameraButton setEdgeInsets:insets];
 
-		if (subview.frame.origin.x < 50) {
-			CGRect flashlight = subview.frame;
+	UIUserInterfaceLayoutDirection layoutDirection = [UIApplication sharedApplication].userInterfaceLayoutDirection;
+	CGRect _referenceBounds = [UIScreen mainScreen]._referenceBounds;
+	CGFloat buttonSize = GetButtonSize(_referenceBounds);
+	CGFloat xOffsetPadding = layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft ? insets.right : insets.left;
+	CGFloat buttonWidth = buttonSize + insets.right + insets.left;
+	CGFloat buttonHeight = buttonSize + insets.top + insets.bottom;
+	CGFloat offsetY = _referenceBounds.size.height - buttonHeight - insets.bottom;
 
-			// Fix for Jumper: The extra buttons are already aligned above the original ones, so don't change their Y position
-			CGFloat flashlightOffset = subview.alpha > 0 ? (flashlight.origin.y - 90 + flashlightY) : flashlight.origin.y;
-
-			flashlight = CGRectMake(46 + flashlightX, flashlightOffset, 50, 50);
-
-			subview.frame = flashlight;
-			[subview sb_removeAllSubviews];
-			[subview init];
-		} else {
-			CGFloat _screenWidth = [UIScreen mainScreen].bounds.size.width;
-			CGRect camera = subview.frame;
-
-			// Fix for Jumper: The extra buttons are already aligned above the original ones, so don't change their Y position
-			CGFloat cameraOffset = subview.alpha > 0 ? (camera.origin.y - 90 + cameraY) : camera.origin.y;
-
-			camera = CGRectMake((_screenWidth - 96) + cameraX, cameraOffset, 50, 50);
-
-			subview.frame = camera;
-			[subview sb_removeAllSubviews];
-			[subview init];
-		}
+	CGRect flashLightRect;
+	CGRect cameraRect;
+	if (layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+		flashLightRect = CGRectMake(_referenceBounds.size.width - xOffsetPadding - buttonWidth + flashlightX, offsetY + flashlightY, buttonWidth, buttonHeight);
+		cameraRect = CGRectMake(xOffsetPadding + cameraX, offsetY + cameraY, buttonWidth, buttonHeight);
+	} else {
+		flashLightRect = CGRectMake(xOffsetPadding + flashlightX, offsetY + flashlightY, buttonWidth, buttonHeight);
+		cameraRect = CGRectMake(_referenceBounds.size.width - xOffsetPadding - buttonHeight + cameraX, offsetY + cameraY, buttonWidth, buttonHeight);
 	}
-}
--(void)_addOrRemoveCameraButtonIfNecessary {
-	%orig;
-
-	// Necessary to change the position of the buttons without a respring
-	if (settingsUpdated) {
-		[self _layoutQuickActionButtons];
-		settingsUpdated = NO;
-	}
+	self.flashlightButton.frame = flashLightRect;
+	self.cameraButton.frame = cameraRect;
 }
 
 -(void)handleButtonTouchBegan:(id)arg1 {
@@ -69,6 +61,11 @@ static void loadPrefs() {
 	NSMutableDictionary *prefs = [[NSMutableDictionary alloc] initWithContentsOfFile:@"/var/mobile/Library/Preferences/com.noisyflake.shortcutenabler.plist"];
 
 	if (prefs) {
+		CGFloat prevFlashlightX = flashlightX;
+		CGFloat prevFlashlightY = flashlightY;
+		CGFloat prevCameraX = cameraX;
+		CGFloat prevCameraY = cameraY;
+
 		showFlashlight = ( [prefs objectForKey:@"showFlashlight"] ? [[prefs objectForKey:@"showFlashlight"] boolValue] : YES );
 		showCamera = ( [prefs objectForKey:@"showCamera"] ? [[prefs objectForKey:@"showCamera"] boolValue] : YES );
 		require3DTouch = ( [prefs objectForKey:@"require3DTouch"] ? [[prefs objectForKey:@"require3DTouch"] boolValue] : YES );
@@ -78,7 +75,12 @@ static void loadPrefs() {
 		cameraX = ( [prefs objectForKey:@"cameraX"] ? [[prefs objectForKey:@"cameraX"] doubleValue] : 0 );
 		cameraY = ( [prefs objectForKey:@"cameraY"] ? [[prefs objectForKey:@"cameraY"] doubleValue] : 0 );
 
-		settingsUpdated = YES;
+		// force update the layout if preferences changed
+		if (prevFlashlightX != flashlightX || prevFlashlightY != flashlightY || prevCameraX != cameraX || prevCameraY != cameraY) {
+			SBDashBoardViewController *dashBoardViewController = [%c(SBLockScreenManager) sharedInstanceIfExists].dashBoardViewController;
+			SBDashBoardQuickActionsViewController *quickActionsViewController = [dashBoardViewController valueForKey:@"_quickActionsViewController"];
+			[[quickActionsViewController quickActionsViewIfLoaded] _layoutQuickActionButtons];
+		}
 	}
 
 	[prefs release];


### PR DESCRIPTION
More native way of calculating the frames for the flashlight and camera buttons. This is how apple calculates the frames, also this should remove the need to remove all subviews and re-initializing them. Not having to re-initialize should give a performance boost since it doesn't have to reinitialize everything for the class.

Haven't tested with jumper, might have completely broke it or just works. I am guessing it just works since it doesn't modify jumper buttons anymore.

Also, I only tested this on iOS 12.4, but it should work from iOS 11 - 12 since all the methods exist in those iOS versions.